### PR TITLE
모입 게시판 사진첨부 수정 API 개선

### DIFF
--- a/src/course/rest/club/board/ClubBoard.http
+++ b/src/course/rest/club/board/ClubBoard.http
@@ -8,27 +8,48 @@ Authorization: Bearer {{token-sdm}}
   "title"    : "테스트 제목",
   "content"  : "테스트 글"  ,
   "category" : "NORMAL"   ,
-  "imgUrl"   : [{
-    "absolutePath" : "https://super-invention-static.s3.ap-northeast-2.amazonaws.com/temp/img/20201212112310-c234aede-b227-4fd3-a02c-13a86624c7ef-test.png",
-    "filePath"     : "/temp/img/20201212112310-c234aede-b227-4fd3-a02c-13a86624c7ef-test.png",
-    "fileName"     : "20201212112310-c234aede-b227-4fd3-a02c-13a86624c7ef-test.png"
+  "imgList"   : [{
+    "absolutePath": "https://super-invention-static.s3.ap-northeast-2.amazonaws.com/temp/img/20210417083305-f001c13f-b310-4e04-a70f-eace30bdfa01-test.jpg",
+    "filePath": "temp/img/20210417083305-f001c13f-b310-4e04-a70f-eace30bdfa01-test.jpg",
+    "fileName": "20210417083305-f001c13f-b310-4e04-a70f-eace30bdfa01-test.jpg"
   }]
 }
 
 ### 모임 게시판 글 수정
-PUT {{host}}/clubs/6327/board/67
+PUT {{host}}/clubs/6327/board/83
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Authorization: Bearer {{token-sdm}}
 
 {
-  "title"    : "테스트 제목 - 수정됨",
-  "content"  : "테스트 글   - 수정됨" ,
-  "imgAddList"   : [{
-    "absolutePath": "https://super-invention-static.s3.ap-northeast-2.amazonaws.com/temp/img/20210411103757-854080b9-f5a6-43c8-8fb8-05f42a23b05e-s3-img13346524765970679600test-img.jpg",
-    "filePath": "temp/img/20210411103757-854080b9-f5a6-43c8-8fb8-05f42a23b05e-s3-img13346524765970679600test-img.jpg",
-    "fileName": "20210411103757-854080b9-f5a6-43c8-8fb8-05f42a23b05e-s3-img13346524765970679600test-img.jpg"
-  }]
+  "title": "테스트 제목 - 수정됨",
+  "content": "테스트 글   - 수정됨",
+  "imageList": [
+    {
+      "imgSeq": 35,
+      "img": {
+        "absolutePath": "http://mannal.ga/static/img/clubBoardImg/83/20210417083842-f8614f92-07f0-49f0-9259-10541efb6e43-test.jpg",
+        "filePath": "clubBoardImg/83/20210417083842-f8614f92-07f0-49f0-9259-10541efb6e43-test.jpg",
+        "fileName": "20210417083842-f8614f92-07f0-49f0-9259-10541efb6e43-test.jpg"
+      }
+    },
+    {
+      "imgSeq": null,
+      "img" : {
+        "absolutePath": "https://super-invention-static.s3.ap-northeast-2.amazonaws.com/temp/img/20210417084738-42bbe8e1-1267-4e89-8fef-94040908cf0c-test.jpg",
+        "filePath": "temp/img/20210417084738-42bbe8e1-1267-4e89-8fef-94040908cf0c-test.jpg",
+        "fileName": "20210417084738-42bbe8e1-1267-4e89-8fef-94040908cf0c-test.jpg"
+      }
+    },
+    {
+      "imgSeq": 33,
+      "img" : {
+        "absolutePath": "https://super-invention-static.s3.ap-northeast-2.amazonaws.com/temp/img/20210417083542-877db044-6eb2-4e35-8b28-87268114e34d-test.jpg",
+        "filePath": "temp/img/20210417083542-877db044-6eb2-4e35-8b28-87268114e34d-test.jpg",
+        "fileName": "20210417083542-877db044-6eb2-4e35-8b28-87268114e34d-test.jpg"
+      }
+    }
+  ]
 }
 
 
@@ -39,7 +60,7 @@ Accept: application/json
 Authorization: Bearer {{token-sdm}}
 
 ### 모임 게시판 글 단건 조회
-GET {{host}}/clubs/6327/board/43
+GET {{host}}/clubs/6327/board/83
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Authorization: Bearer {{token-dong}}
+Authorization: Bearer {{token-sdm}}

--- a/src/course/rest/user/user.http
+++ b/src/course/rest/user/user.http
@@ -2,7 +2,7 @@
 GET {{host}} /users/check-already-register
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDM5NTI4NTk3Iiwic3ViIjoiMTQzOTUyODU5NyIsImlhdCI6MTYxNzA5MDk3NiwiZXhwIjoxNjE3MDkyNzc2fQ.WC21kPa-PkFCsAbm2gWFQo0g3hlHd5IzKZqvbq2w19I
+Authorization: Bearer {{token-sdm}}
 
 ### 유저 백도어 조회
 GET {{host}}/users/door/꽑꽑이
@@ -26,7 +26,7 @@ Content-type: application/x-www-form-urlencoded;charset=utf-8
 
 ### 카카오 유저 정보
 GET {{host}}/users/kakao-profile
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDEyMzc1MzA5Iiwic3ViIjoiMTQxMjM3NTMwOSIsImlhdCI6MTYxMTQ4NTEwOCwiZXhwIjoxNjQzMDIxMTA4fQ.gJg2APZdNtewO_OIfkAhbLB0ZJzBYrTZUjR72JvzXqI
+Authorization: Bearer {{token-sdm}}
 
 ### 카카오 유저 정보
 GET {{host}}/users/kakao-profile
@@ -54,7 +54,7 @@ Authorization: Bearer {{token-tester}}
 GET {{host}}/users/profile
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDM5NTI4NTk3Iiwic3ViIjoiMTQzOTUyODU5NyIsImlhdCI6MTYxNzEyMzExOCwiZXhwIjoxNjQ4NjU5MTE4fQ.kCvbUinWut0cP9h7Sd_XJ7SfmWGWbSIi-LpeHIodMnk
+Authorization: Bearer {{token-sdm}}
 
 
 ### 내 정보

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/ClubService.kt
@@ -58,7 +58,6 @@ class ClubService(
         private var roleService: RoleService,
         private var interestService: InterestService,
         private var regionService: RegionService,
-        private var userRepository: UserRepository,
         private var clubUserRepository: ClubUserRepository,
         private var clubInterestRepository: ClubInterestRepository,
         private var clubRegionRepository: ClubRegionRepository,

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/album/image/ClubAlbumImageService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/album/image/ClubAlbumImageService.kt
@@ -18,7 +18,7 @@ class ClubAlbumImageService (
     fun registerClubAlbumImage(clubAlbum: ClubAlbum, s3Path: S3Path): S3Path {
         val imgFolder = "clubAlbumImg/${clubAlbum.seq}"
         val movedFile = awsS3Mo.moveFile(s3Path, "$imgFolder/${s3Path.fileName}")
-        val webpFile  = webpConvertService.convertToWebP(movedFile)
+        webpConvertService.convertToWebP(movedFile)
 
         clubAlbum.img_url   = movedFile.filePath
         clubAlbum.file_name = movedFile.fileName
@@ -31,7 +31,7 @@ class ClubAlbumImageService (
 
         val imgFolder = "clubAlbumImg/${clubAlbum.seq}"
         val movedFile = awsS3Mo.moveFile(s3Path, "$imgFolder/${s3Path.fileName}")
-        val webpFile  = webpConvertService.convertToWebP(movedFile)
+        webpConvertService.convertToWebP(movedFile)
 
         deleteAlbumImg(clubAlbum)
 

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardService.kt
@@ -23,11 +23,11 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ClubBoardService(
-        private val roleService: RoleService,
-        private val clubBoardImgService: ClubBoardImgService,
+        private val roleService            : RoleService,
+        private val clubBoardImgService    : ClubBoardImgService,
         private val clubBoardLikeRepository: ClubBoardLikeRepository,
-        private val clubBoardRepository: ClubBoardRepository,
-        private val clubUserRepository: ClubUserRepository,
+        private val clubBoardRepository    : ClubBoardRepository,
+        private val clubUserRepository     : ClubUserRepository,
 
         @Value("\${host.static.path}")
         private var imgHost: String,
@@ -134,7 +134,6 @@ class ClubBoardService(
             if(body.category == ClubBoard.Category.NOTICE && roleService.hasClubManagerAuth(actor)) {
                 throw InsufficientAuthException("매니저, 마스터만 공지사항으로 공지사항으로 변경할 수 있습니다. ", HttpStatus.FORBIDDEN)
             }
-
             clubBoard.category = body.category
         }
 
@@ -146,23 +145,11 @@ class ClubBoardService(
             clubBoard.content = body.content
         }
 
-        val clubBoardImgs = clubBoardImgService.getImageList(clubBoard)
-        if(body.imgDeleteList.isNotEmpty()) {
-            val deleteImgSeq: List<Long> = clubBoardImgs
-                .filter { clubBoardImgDto -> body.imgDeleteList.contains(clubBoardImgDto.imgSeq) }
-                .map { dto -> dto.imgSeq }
-
-            clubBoardImgService.softDeleteImageBySeqIn(deleteImgSeq)
-        }
-
-        if(body.imgAddList.isNotEmpty()) {
-            clubBoardImgService.registerImg(clubBoard, body.imgAddList)
+        if(body.imageList.isNotEmpty()) {
+            clubBoardImgService.editClubBoardImages(clubBoard, body.imageList)
         }
     }
 
-    /**
-     * 게시판 글 삭제
-     */
     @Transactional
     fun deleteClubBoard(user: User, clubBoardSeq: Long) {
         val clubBoard: ClubBoard = clubBoardRepository.findBySeq(clubBoardSeq)

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/comment/ClubBoardCommentRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/comment/ClubBoardCommentRepository.kt
@@ -25,7 +25,7 @@ interface ClubBoardCommentRepositoryCustom {
 }
 
 @Repository
-class ClubBoardCommentRepositoryImpl : ClubBoardCommentRepositoryCustom,
+class ClubBoardCommentRepositoryImpl: ClubBoardCommentRepositoryCustom,
     QuerydslRepositorySupport(ClubBoardComment::class.java) {
 
     companion object {

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/img/ClubBoardImg.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/img/ClubBoardImg.kt
@@ -18,5 +18,7 @@ class ClubBoardImg(
 
     var imgName: String,
 
+    var displayOrder: Long?,
+
     var deleteFlag: Boolean
 ): BaseEntity()

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/img/ClubBoardImgRepository.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/img/ClubBoardImgRepository.kt
@@ -1,10 +1,34 @@
 package com.taskforce.superinvention.app.domain.club.board.img
 
 import com.taskforce.superinvention.app.domain.club.board.ClubBoard
+import com.taskforce.superinvention.app.domain.club.board.comment.ClubBoardComment
+import com.taskforce.superinvention.app.domain.club.board.comment.ClubBoardCommentRepositoryCustom
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.stereotype.Repository
 
-interface ClubBoardImgRepository : JpaRepository<ClubBoardImg, Long> {
+interface ClubBoardImgRepository : JpaRepository<ClubBoardImg, Long>, ClubBoardImgRepositoryCustom {
     fun findByClubBoard(clubBoard: ClubBoard): List<ClubBoardImg>
-    fun findByClubBoardOrderByCreatedAtAsc(clubBoard: ClubBoard): List<ClubBoardImg>
     fun findBySeqIn(clubBoardSeqList: List<Long>): List<ClubBoardImg>
+}
+
+interface ClubBoardImgRepositoryCustom {
+    fun findByClubBoardOrderByOrderAsc(clubBoard: ClubBoard): List<ClubBoardImg>
+}
+
+@Repository
+class ClubBoardImgRepositoryImpl: ClubBoardImgRepositoryCustom,
+    QuerydslRepositorySupport(ClubBoardImg::class.java) {
+
+    override fun findByClubBoardOrderByOrderAsc(clubBoard: ClubBoard): List<ClubBoardImg> {
+        val clubBoardImg = QClubBoardImg.clubBoardImg
+
+        return from(clubBoardImg)
+            .where(
+                clubBoardImg.clubBoard.eq(clubBoard),
+                clubBoardImg.deleteFlag.isFalse,
+            )
+            .orderBy(clubBoardImg.displayOrder.asc())
+            .fetch()
+    }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/img/ClubBoardImgService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/img/ClubBoardImgService.kt
@@ -3,6 +3,7 @@ package com.taskforce.superinvention.app.domain.club.board.img
 import com.taskforce.superinvention.app.domain.club.board.ClubBoard
 import com.taskforce.superinvention.app.domain.common.image.webp.convert.WebpConvertService
 import com.taskforce.superinvention.app.web.dto.club.board.ClubBoardImgDto
+import com.taskforce.superinvention.app.web.dto.club.board.img.ClubBoardImgEditS3Path
 import com.taskforce.superinvention.common.util.aws.s3.AwsS3Mo
 import com.taskforce.superinvention.common.util.aws.s3.S3Path
 import org.springframework.beans.factory.annotation.Value
@@ -19,24 +20,21 @@ class ClubBoardImgService(
     private var imgHost: String,
 ) {
 
-
-    /**
-     * 글 등록시, 이미지 같이 등록
-     */
     @Transactional
     fun registerImg(clubBoard: ClubBoard, imgList: List<S3Path>): List<ClubBoardImg> {
         val imgFolder = "clubBoardImg/${clubBoard.seq}"
 
         // [1] 기존 임시 저장된 파일들을 해당 폴더로 이동
-        val clubBoardImgList = imgList.map { s3Path ->
+        val clubBoardImgList = imgList.mapIndexed{ idx, s3Path ->
             val movedFile: S3Path = awsS3Mo.moveFile(s3Path, "$imgFolder/${s3Path.fileName}")
-            val webpFile : S3Path = webpConvertService.convertToWebP(movedFile)
+            webpConvertService.convertToWebP(movedFile)
 
             ClubBoardImg(
-                imgName   = movedFile.fileName,
-                imgUrl    = movedFile.filePath,
-                clubBoard  = clubBoard,
-                deleteFlag = false
+                imgName      = movedFile.fileName,
+                imgUrl       = movedFile.filePath,
+                clubBoard    = clubBoard,
+                displayOrder = idx + 1L,
+                deleteFlag   = false
             )
         }
 
@@ -45,9 +43,27 @@ class ClubBoardImgService(
     }
 
     @Transactional
+    fun registerImg(clubBoard: ClubBoard, s3Path: S3Path, order: Long): ClubBoardImg {
+        val imgFolder = "clubBoardImg/${clubBoard.seq}"
+
+        // [1] 기존 임시 저장된 파일들을 해당 폴더로 이동
+        val movedFile: S3Path = awsS3Mo.moveFile(s3Path, "$imgFolder/${s3Path.fileName}")
+        webpConvertService.convertToWebP(movedFile)
+
+        val clubBoardImg = ClubBoardImg(
+            imgName = movedFile.fileName,
+            imgUrl = movedFile.filePath,
+            clubBoard = clubBoard,
+            displayOrder = order,
+            deleteFlag = false
+        )
+
+        return clubBoardImgRepository.save(clubBoardImg)
+    }
+
+    @Transactional
     fun getImageList(clubBoard: ClubBoard): List<ClubBoardImgDto> {
-       return clubBoardImgRepository.findByClubBoardOrderByCreatedAtAsc(clubBoard)
-           .filterNot { clubBoardImg -> clubBoardImg.deleteFlag }
+       return clubBoardImgRepository.findByClubBoardOrderByOrderAsc(clubBoard)
            .map { clubBoardImg -> ClubBoardImgDto(
                imgHost      = imgHost,
                clubBoardImg = clubBoardImg
@@ -65,9 +81,48 @@ class ClubBoardImgService(
     fun softDeleteImageAllInClubBoard(clubBoard: ClubBoard) {
         val imgList =  clubBoardImgRepository.findByClubBoard(clubBoard)
 
-        imgList.forEach{ clubBoardImg -> clubBoardImg.deleteFlag = true}
+        imgList.forEach{ clubBoardImg ->
+            clubBoardImg.deleteFlag = true
+            clubBoardImg.displayOrder      = null
+        }
 
         // [1] 해당 이미지 DB에서 제거 / flag 처리
         clubBoardImgRepository.saveAll(imgList)
     }
+
+    @Transactional
+    fun editClubBoardImages(clubBoard: ClubBoard, editImageList: List<ClubBoardImgEditS3Path>) {
+        val clubBoardImgs = clubBoardImgRepository.findByClubBoardOrderByOrderAsc(clubBoard)
+        val overrideImgs  = editImageList.filter { img -> img.imgSeq != null }
+                                         .map{ editS3Path-> editS3Path.imgSeq!!}
+                                         .toList()
+
+        // editImageList에 없는 이미지는 삭제처리
+        for (clubBoardImg in clubBoardImgs) {
+            if(!overrideImgs.contains(clubBoardImg.seq)) {
+                clubBoardImg.deleteFlag = true
+                clubBoardImg.displayOrder      = null
+            }
+        }
+
+        // 이미지 순차 저장 처리
+        var order = 1L
+        for(editS3Path in editImageList) {
+
+            if(editS3Path.imgSeq != null) {
+                val clubBoardImg = clubBoardImgs.firstOrNull { clubBoardImg -> clubBoardImg.seq == editS3Path.imgSeq }
+                if(clubBoardImg != null) {
+                    clubBoardImg.displayOrder = order
+                    order++
+                }
+            } else {
+                registerImg(
+                    clubBoard = clubBoard,
+                    s3Path    = editS3Path.image,
+                    order     = order
+                )
+            }
+        }
+    }
+
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/img/ClubBoardImgService.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/club/board/img/ClubBoardImgService.kt
@@ -82,8 +82,8 @@ class ClubBoardImgService(
         val imgList =  clubBoardImgRepository.findByClubBoard(clubBoard)
 
         imgList.forEach{ clubBoardImg ->
-            clubBoardImg.deleteFlag = true
-            clubBoardImg.displayOrder      = null
+            clubBoardImg.deleteFlag   = true
+            clubBoardImg.displayOrder = null
         }
 
         // [1] 해당 이미지 DB에서 제거 / flag 처리
@@ -118,9 +118,10 @@ class ClubBoardImgService(
             } else {
                 registerImg(
                     clubBoard = clubBoard,
-                    s3Path    = editS3Path.image,
+                    s3Path    = editS3Path.img,
                     order     = order
                 )
+                order++
             }
         }
     }

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/common/image/resize/strategy/GifResizeStrategy.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/common/image/resize/strategy/GifResizeStrategy.kt
@@ -2,12 +2,8 @@ package com.taskforce.superinvention.app.domain.common.image.resize.strategy
 
 import com.drew.imaging.ImageMetadataReader
 import com.sksamuel.scrimage.ImmutableImage
-import com.sksamuel.scrimage.Position
 import com.sksamuel.scrimage.nio.GifWriter
-import com.sksamuel.scrimage.nio.JpegWriter
-import com.sksamuel.scrimage.webp.WebpWriter
 import com.taskforce.superinvention.app.domain.common.image.ImageFormat
-import com.taskforce.superinvention.app.domain.common.image.webp.convert.handler.WebpAnimatedWriter
 import com.taskforce.superinvention.app.web.dto.common.image.ResizeDto
 import com.taskforce.superinvention.common.util.file.image.gif.GifMo
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/common/image/webp/convert/handler/Gif2WebpHandler.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/common/image/webp/convert/handler/Gif2WebpHandler.kt
@@ -30,10 +30,10 @@ class Gif2WebpHandler : WebpHandler() {
         }
     }
 
-    fun convert(gifFile: File, q: Int, m: Int, lossy: Boolean): ByteArray {
+    fun convert(gifFile: File, q: Int, m: Int, lossy: Boolean, mixed: Boolean, multiThreaded: Boolean): ByteArray {
         return try {
             val target = Files.createTempFile("to_webp", "webp").toAbsolutePath()
-            convert(gifFile.toPath().toAbsolutePath(), target, m, q, lossy)
+            convert(gifFile.toPath().toAbsolutePath(), target, m, q, lossy, mixed, multiThreaded)
             Files.readAllBytes(target)
         } finally {
             gifFile.delete()
@@ -45,7 +45,9 @@ class Gif2WebpHandler : WebpHandler() {
         target: Path,
         m: Int,
         q: Int,
-        lossy: Boolean
+        lossy: Boolean,
+        mixed: Boolean,
+        multiThreaded: Boolean
     ) {
         val stdout = Files.createTempFile("stdout", "webp")
         val commands: MutableList<String> = ArrayList(5)
@@ -60,8 +62,17 @@ class Gif2WebpHandler : WebpHandler() {
             commands.add("-q")
             commands.add(q.toString())
         }
+
         if (lossy) {
             commands.add("-lossy")
+        }
+
+        if(mixed) {
+            commands.add("-mixed")
+        }
+
+        if(multiThreaded) {
+            commands.add("-mt")
         }
 
         commands.add(input.toAbsolutePath().toString())

--- a/src/main/kotlin/com/taskforce/superinvention/app/domain/common/image/webp/convert/handler/WebpAnimatedWriter.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/domain/common/image/webp/convert/handler/WebpAnimatedWriter.kt
@@ -5,7 +5,9 @@ import java.io.File
 class WebpAnimatedWriter(
     private var q: Int = -1,
     private var m: Int = -1,
+    private var mixed: Boolean = true,
     private var lossy: Boolean = true,
+    private var multiThread: Boolean = true,
 ) {
 
     companion object {
@@ -32,6 +34,6 @@ class WebpAnimatedWriter(
     }
 
     fun writeAsByteArray(gifImage: File): ByteArray {
-        return handler.convert(gifImage, q, m, lossy)
+        return handler.convert(gifImage, q, m, lossy, mixed, multiThread)
     }
 }

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/board/ClubBoardDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/board/ClubBoardDto.kt
@@ -3,6 +3,7 @@ package com.taskforce.superinvention.app.web.dto.club.board
 import com.taskforce.superinvention.app.domain.club.board.ClubBoard
 import com.taskforce.superinvention.app.domain.club.board.img.ClubBoardImg
 import com.taskforce.superinvention.app.web.dto.club.ClubWriter
+import com.taskforce.superinvention.app.web.dto.club.board.img.ClubBoardImgEditS3Path
 import com.taskforce.superinvention.common.util.aws.s3.S3Path
 import com.taskforce.superinvention.common.util.extendFun.sliceIfExceed
 import com.taskforce.superinvention.common.util.extendFun.toBaseDateTime
@@ -24,8 +25,7 @@ data class ClubBoardEditBody(
     val content : String?,
     val category: ClubBoard.Category?,
 
-    val imgAddList     : List<S3Path> = emptyList(),
-    val imgDeleteList  : List<Long>   = emptyList()
+    val imageList : List<ClubBoardImgEditS3Path> = emptyList(),
 )
 
 data class ClubBoardSearchOpt(

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/board/img/ClubBoardImgDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/board/img/ClubBoardImgDto.kt
@@ -1,0 +1,8 @@
+package com.taskforce.superinvention.app.web.dto.club.board.img
+
+import com.taskforce.superinvention.common.util.aws.s3.S3Path
+
+data class ClubBoardImgEditS3Path (
+    val imgSeq: Long?,
+    val image: S3Path
+)

--- a/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/board/img/ClubBoardImgDto.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/app/web/dto/club/board/img/ClubBoardImgDto.kt
@@ -4,5 +4,5 @@ import com.taskforce.superinvention.common.util.aws.s3.S3Path
 
 data class ClubBoardImgEditS3Path (
     val imgSeq: Long?,
-    val image: S3Path
+    val img: S3Path
 )

--- a/src/main/kotlin/com/taskforce/superinvention/common/config/async/AsyncConfig.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/config/async/AsyncConfig.kt
@@ -1,0 +1,27 @@
+package com.taskforce.superinvention.common.config.async
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+
+    companion object {
+        const val WEBP_CONVERSION = "webpConversion"
+    }
+
+    @Bean(WEBP_CONVERSION)
+    fun webpConversionAsyncTaskExecutor(): Executor {
+
+        val threadPoolTaskExecutor = ThreadPoolTaskExecutor()
+        threadPoolTaskExecutor.corePoolSize = 10
+        threadPoolTaskExecutor.maxPoolSize  = 30
+        threadPoolTaskExecutor.setThreadNamePrefix("super-invention-webp-conversion")
+
+        return threadPoolTaskExecutor
+    }
+}

--- a/src/test/kotlin/com/taskforce/superinvention/app/domain/club/ClubServiceTest.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/app/domain/club/ClubServiceTest.kt
@@ -92,7 +92,6 @@ internal class ClubServiceTest: MockTest() {
             interestService = interestService,
             regionService = regionService,
             roleService = roleService,
-            userRepository = userRepository,
             clubAlbumRepository = clubAlbumRepository,
             clubAlbumCommentRepository = clubAlbumCommentRepository,
             clubBoardRepository = clubBoardRepository,

--- a/src/test/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardServiceTest.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardServiceTest.kt
@@ -179,7 +179,7 @@ internal class ClubBoardServiceTest {
             imageList = listOf(
                 ClubBoardImgEditS3Path(
                     imgSeq = null,
-                    image = S3Path(
+                    img = S3Path(
                         absolutePath = "신규이미지-절대경로",
                         filePath     = "신규이미지 상대 경로",
                         fileName     = "신규이미지 이름"
@@ -210,7 +210,7 @@ internal class ClubBoardServiceTest {
             imageList = listOf(
                 ClubBoardImgEditS3Path(
                     imgSeq = null,
-                    image = S3Path(
+                    img = S3Path(
                         absolutePath = "신규이미지-절대경로",
                         filePath     = "신규이미지 상대 경로",
                         fileName     = "신규이미지 이름"

--- a/src/test/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardServiceTest.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/app/domain/club/board/ClubBoardServiceTest.kt
@@ -11,9 +11,11 @@ import com.taskforce.superinvention.app.domain.role.RoleService
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.dto.club.board.ClubBoardEditBody
 import com.taskforce.superinvention.app.web.dto.club.board.ClubBoardRegisterBody
+import com.taskforce.superinvention.app.web.dto.club.board.img.ClubBoardImgEditS3Path
 import com.taskforce.superinvention.common.exception.auth.InsufficientAuthException
 import com.taskforce.superinvention.common.exception.auth.WithdrawClubUserNotAllowedException
 import com.taskforce.superinvention.common.exception.club.UserIsNotClubMemberException
+import com.taskforce.superinvention.common.util.aws.s3.S3Path
 import com.taskforce.superinvention.config.MockitoHelper
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -45,7 +47,6 @@ internal class ClubBoardServiceTest {
         club = Club("mock name", "mock desc", 10, "mainImageURL-url.com").apply { seq = 152125 }
         clubUser  = ClubUser(club, user).apply { seq = 903125 }
         clubBoard = ClubBoard("게시판 제목", "게시판 내용", clubUser, club, ClubBoard.Category.NORMAL).apply { seq = 5153333 }
-
 
         roleService = mockk()
         clubBoardImgService = mockk()
@@ -175,8 +176,16 @@ internal class ClubBoardServiceTest {
             title    = "sss",
             content  = "",
             category = ClubBoard.Category.NORMAL,
-            imgAddList    = emptyList(),
-            imgDeleteList = emptyList()
+            imageList = listOf(
+                ClubBoardImgEditS3Path(
+                    imgSeq = null,
+                    image = S3Path(
+                        absolutePath = "신규이미지-절대경로",
+                        filePath     = "신규이미지 상대 경로",
+                        fileName     = "신규이미지 이름"
+                    )
+                )
+            )
         )
 
         every { clubUserRepository.findByClubSeqAndUser(club.seq!!, actorUser) }.returns(actorClubUser)
@@ -198,8 +207,16 @@ internal class ClubBoardServiceTest {
             title    = "sss",
             content  = "",
             category = ClubBoard.Category.NORMAL,
-            imgAddList    = emptyList(),
-            imgDeleteList = emptyList()
+            imageList = listOf(
+                ClubBoardImgEditS3Path(
+                    imgSeq = null,
+                    image = S3Path(
+                        absolutePath = "신규이미지-절대경로",
+                        filePath     = "신규이미지 상대 경로",
+                        fileName     = "신규이미지 이름"
+                    )
+                )
+            )
         )
 
         every { clubUserRepository.findByClubSeqAndUser(club.seq!!, actorUser) }.returns(actorClubUser)
@@ -242,3 +259,4 @@ internal class ClubBoardServiceTest {
         assertThrows<InsufficientAuthException> { clubBoardService.deleteClubBoard(actorUser, clubBoard.seq!!) }
     }
 }
+

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/board/ClubBoardDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/board/ClubBoardDocumentation.kt
@@ -163,7 +163,7 @@ class ClubBoardDocumentation: ApiDocumentationTestV2() {
             content   = "내용",
             imageList = listOf(ClubBoardImgEditS3Path(
                 imgSeq = 1,
-                image  = s3path
+                img  = s3path
             )),
             category  = ClubBoard.Category.NORMAL,
         )
@@ -193,9 +193,9 @@ class ClubBoardDocumentation: ApiDocumentationTestV2() {
                     fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
                     fieldWithPath("category").type(JsonFieldType.STRING).description("글 상태, NORMAL | NOTICE"),
                     fieldWithPath("imageList[].imgSeq").type(JsonFieldType.NUMBER).description("이미지 seq (신규등록의 경우 제외)"),
-                    fieldWithPath("imageList[].image.absolutePath").type(JsonFieldType.STRING).description("절대 경로"),
-                    fieldWithPath("imageList[].image.filePath").type(JsonFieldType.STRING).description("상대 경로"),
-                    fieldWithPath("imageList[].image.fileName").type(JsonFieldType.STRING).description("파일 명"),
+                    fieldWithPath("imageList[].img.absolutePath").type(JsonFieldType.STRING).description("절대 경로"),
+                    fieldWithPath("imageList[].img.filePath").type(JsonFieldType.STRING).description("상대 경로"),
+                    fieldWithPath("imageList[].img.fileName").type(JsonFieldType.STRING).description("파일 명"),
                 ),
                 responseFields(
                     *commonResponseField()

--- a/src/test/kotlin/com/taskforce/superinvention/document/club/board/ClubBoardDocumentation.kt
+++ b/src/test/kotlin/com/taskforce/superinvention/document/club/board/ClubBoardDocumentation.kt
@@ -14,6 +14,7 @@ import com.taskforce.superinvention.app.domain.role.RoleGroup
 import com.taskforce.superinvention.app.domain.user.User
 import com.taskforce.superinvention.app.web.controller.club.board.ClubBoardController
 import com.taskforce.superinvention.app.web.dto.club.board.*
+import com.taskforce.superinvention.app.web.dto.club.board.img.ClubBoardImgEditS3Path
 import com.taskforce.superinvention.app.web.dto.common.PageDto
 import com.taskforce.superinvention.common.util.aws.s3.S3Path
 import com.taskforce.superinvention.config.documentation.ApiDocumentUtil.commonPageQueryParam
@@ -87,9 +88,10 @@ class ClubBoardDocumentation: ApiDocumentationTestV2() {
         }
 
         clubBoardImg = ClubBoardImg (
-            clubBoard = clubBoard,
-            imgUrl    = "이미지 절대 경로",
-            imgName   = "",
+            clubBoard  = clubBoard,
+            imgUrl     = "이미지 절대 경로",
+            imgName    = "",
+            displayOrder      = 1,
             deleteFlag = false
         ).apply {
             seq = 301
@@ -157,11 +159,13 @@ class ClubBoardDocumentation: ApiDocumentationTestV2() {
         )
 
         val editBody = ClubBoardEditBody(
-            title    = "글 제목",
-            content  = "내용",
-            imgAddList    = listOf(s3path),
-            imgDeleteList = listOf(clubBoardImg.seq!!),
-            category      = ClubBoard.Category.NORMAL,
+            title     = "글 제목",
+            content   = "내용",
+            imageList = listOf(ClubBoardImgEditS3Path(
+                imgSeq = 1,
+                image  = s3path
+            )),
+            category  = ClubBoard.Category.NORMAL,
         )
 
         // when
@@ -188,10 +192,10 @@ class ClubBoardDocumentation: ApiDocumentationTestV2() {
                     fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
                     fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
                     fieldWithPath("category").type(JsonFieldType.STRING).description("글 상태, NORMAL | NOTICE"),
-                    fieldWithPath("imgAddList[].absolutePath").type(JsonFieldType.STRING).description("전체 경로 ( 도메인 포함 )"),
-                    fieldWithPath("imgAddList[].filePath").type(JsonFieldType.STRING).description("파일 경로"),
-                    fieldWithPath("imgAddList[].fileName").type(JsonFieldType.STRING).description("파일 명"),
-                    fieldWithPath("imgDeleteList[]").type(JsonFieldType.ARRAY).description("삭제할 이미지 seq 리스트"),
+                    fieldWithPath("imageList[].imgSeq").type(JsonFieldType.NUMBER).description("이미지 seq (신규등록의 경우 제외)"),
+                    fieldWithPath("imageList[].image.absolutePath").type(JsonFieldType.STRING).description("절대 경로"),
+                    fieldWithPath("imageList[].image.filePath").type(JsonFieldType.STRING).description("상대 경로"),
+                    fieldWithPath("imageList[].image.fileName").type(JsonFieldType.STRING).description("파일 명"),
                 ),
                 responseFields(
                     *commonResponseField()


### PR DESCRIPTION
변경점 

- webp 변환하는데 시간이 너무 오래걸려서 비동기로 처리하도록 수정
  -> webp 로 변환하는걸 기다려줄 필요는 없을듯하네요 

- 사진첩 수정시 이미지를 삭제할 이미지 따로, 추가할 이미지 따로, 받던 부분을 
한번에 모든 이미지로 받도록 수정

기타 작업중 